### PR TITLE
Don't log software reset on exception

### DIFF
--- a/bl_include/sw_wdt.h
+++ b/bl_include/sw_wdt.h
@@ -1,0 +1,15 @@
+/*
+ * sw_wdt.h
+ *
+ *  Created on: Sep. 27, 2022
+ *      Author: robert
+ */
+
+#ifndef EX2_SYSTEM_INCLUDE_SW_WDT_H_
+#define EX2_SYSTEM_INCLUDE_SW_WDT_H_
+
+#include "system.h"
+
+SAT_returnState start_sw_watchdog();
+
+#endif /* EX2_SYSTEM_INCLUDE_SW_WDT_H_ */

--- a/bl_source/sw_wdt.c
+++ b/bl_source/sw_wdt.c
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2022  University of Alberta
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+/*
+ * sw_wdt.c
+ *
+ *  Created on: Sep. 27, 2022
+ *      Author: Robert Taylor
+ */
+
+#include <FreeRTOS.h>
+#include <os_task.h>
+#include "system.h"
+#include "HL_reg_rti.h"
+#include "privileged_functions.h"
+
+void pet_dog() {
+#if WATCHDOG_IS_STUBBED == 0
+    RAISE_PRIVILEGE;
+    portENTER_CRITICAL();
+    rtiREG1->WDKEY = 0x0000E51AU;
+    rtiREG1->WDKEY = 0x0000A35CU;
+    portEXIT_CRITICAL();
+    RESET_PRIVILEGE;
+#endif
+}
+
+void start_dog() {
+#if WATCHDOG_IS_STUBBED == 0
+    RAISE_PRIVILEGE;
+    rtiREG1->WDSTATUS = 0xFFU;
+    rtiREG1->DWDPRLD = 0xFFFF;
+    rtiREG1->DWDCTRL = 0xA98559DA;
+    RESET_PRIVILEGE;
+#endif
+}
+
+// the purpose of this software watchdog is to pet the dog indiscriminately. This prevents some latch-up scenarios
+void sw_watchdog(void *pvParameters) {
+    TickType_t last_wake_time = xTaskGetTickCount();
+    start_dog();
+    for (;;) {
+        pet_dog();
+        vTaskDelayUntil(&last_wake_time, WDT_DELAY);
+    }
+}
+
+SAT_returnState start_sw_watchdog() {
+    xTaskCreate(sw_watchdog, "WDT", 128, NULL, configMAX_PRIORITIES - 1, NULL);
+    return SATR_OK;
+}

--- a/main/bl_main.c
+++ b/main/bl_main.c
@@ -155,6 +155,7 @@ char get_boot_type(resetSource_t rstsrc, boot_info *b_inf) {
     case EXT_RESET:
         return 'B';
     case SW_RESET:
+    case WATCHDOG_RESET:
         if (b_inf->attempts >= 5) {
             b_inf->attempts = 0;
             if (stored_boot_type == 'A') {

--- a/main/bl_main.c
+++ b/main/bl_main.c
@@ -5,7 +5,6 @@
 #include "HL_system.h"
 #include "HL_rti.h"
 #include "HL_gio.h"
-#include "ti_fee.h"
 #include "bl_eeprom.h"
 #include "bl_launch.h"
 #include "HL_sci.h"
@@ -25,6 +24,7 @@
 #include <csp/interfaces/csp_if_sdr.h>
 #include "csp/crypto/csp_hmac.h"
 #include "csp/crypto/csp_xtea.h"
+#include "sw_wdt.h"
 #define INIT_PRIO configMAX_PRIORITIES - 1
 #define INIT_STACK_SIZE 1500
 
@@ -138,7 +138,7 @@ static void init_csp() {
 }
 
 void bl_init(void *pvParameters) {
-    printf("Hello world!\n");
+    start_sw_watchdog();
     init_csp();
     start_service_server();
     vTaskDelete(0);
@@ -215,7 +215,9 @@ void vAssertCalled(unsigned long ulLine, const char *const pcFileName) {
     (void)pcFileName;
 
     printf("ASSERT! Line %d, file %s\r\n", ulLine, pcFileName);
-    sw_reset('B', DABORT);
+    RAISE_PRIVILEGE;
+    systemREG1->SYSECR = (0x10) << 14;
+    RESET_PRIVILEGE;
 }
 
 void initializeProfiler() {

--- a/main/system.h
+++ b/main/system.h
@@ -56,6 +56,9 @@ typedef enum {
 } SAT_returnState;
 //#define   DEBUG_MSG_L3
 
+// watchdog timer expires in 447ms
+#define WDT_DELAY 300 // 300 miliseconds gives a a good window
+
 /**
  * SANITY CHECKS
  */

--- a/source/HL_sys_startup.c
+++ b/source/HL_sys_startup.c
@@ -342,7 +342,7 @@ void handlePLLLockFail(void)
 #pragma INTERRUPT(_c_int00, UDEF)
 void _undef(void) {
     while(1) {
-        sw_reset(0, UNDEF);
+        systemREG1->SYSECR = (0x10) << 14;
     }
 }
 
@@ -350,7 +350,7 @@ void _undef(void) {
 #pragma INTERRUPT(_c_int00, PABT)
 void _prefetch (void) {
     while(1) {
-        sw_reset(0, PREFETCH);
+        systemREG1->SYSECR = (0x10) << 14;
     }
 }
 
@@ -358,7 +358,7 @@ void _prefetch (void) {
 #pragma INTERRUPT(_c_int00, DABT)
 void _dabort (void) {
     while(1) {
-        sw_reset(0, DABORT);
+        systemREG1->SYSECR = (0x10) << 14;
     }
 }
 


### PR DESCRIPTION
When we reach these exception handlers, we can't trust that the CPU is in a good state or that the C environment is in a good state
These exceptions do have their own stacks, so the C environment may be good. But without the CPU in a good state there's not much we can do with it

It may be possible to store exception state in the RAM and access it after reset. That will be a future task